### PR TITLE
Add database migrations and initial backend setup

### DIFF
--- a/backend/migrations/.gitkeep
+++ b/backend/migrations/.gitkeep
@@ -1,0 +1,1 @@
+// Keep folder for TypeORM migrations

--- a/backend/migrations/001-InitialMigration.ts
+++ b/backend/migrations/001-InitialMigration.ts
@@ -1,0 +1,250 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class InitialMigration001 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Enable uuid extension
+        await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`);
+
+        // Roles table
+        await queryRunner.createTable(
+            new Table({
+                name: 'roles',
+                columns: [
+                    { name: 'id', type: 'serial', isPrimary: true },
+                    { name: 'name', type: 'varchar', isUnique: true, isNullable: false },
+                ],
+            }),
+            true,
+        );
+
+        // Users table
+        await queryRunner.createTable(
+            new Table({
+                name: 'users',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'email', type: 'varchar', isUnique: true, isNullable: false },
+                    { name: 'password', type: 'varchar', isNullable: false },
+                    { name: 'first_name', type: 'varchar', isNullable: false },
+                    { name: 'last_name', type: 'varchar', isNullable: false },
+                    { name: 'created_at', type: 'timestamp with time zone', default: 'now()' },
+                    { name: 'updated_at', type: 'timestamp with time zone', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+
+        // User roles join table
+        await queryRunner.createTable(
+            new Table({
+                name: 'user_roles',
+                columns: [
+                    { name: 'user_id', type: 'uuid', isPrimary: true },
+                    { name: 'role_id', type: 'int', isPrimary: true },
+                ],
+            }),
+            true,
+        );
+        await queryRunner.createForeignKey(
+            'user_roles',
+            new TableForeignKey({
+                columnNames: ['user_id'],
+                referencedColumnNames: ['id'],
+                referencedTableName: 'users',
+                onDelete: 'CASCADE',
+            }),
+        );
+        await queryRunner.createForeignKey(
+            'user_roles',
+            new TableForeignKey({
+                columnNames: ['role_id'],
+                referencedColumnNames: ['id'],
+                referencedTableName: 'roles',
+                onDelete: 'CASCADE',
+            }),
+        );
+
+        // Categories table
+        await queryRunner.createTable(
+            new Table({
+                name: 'categories',
+                columns: [
+                    { name: 'id', type: 'serial', isPrimary: true },
+                    { name: 'name', type: 'varchar', isUnique: true, isNullable: false },
+                    { name: 'description', type: 'text', isNullable: true },
+                ],
+            }),
+            true,
+        );
+
+        // Venues table
+        await queryRunner.createTable(
+            new Table({
+                name: 'venues',
+                columns: [
+                    { name: 'id', type: 'serial', isPrimary: true },
+                    { name: 'name', type: 'varchar', isNullable: false },
+                    { name: 'description', type: 'text', isNullable: true },
+                    { name: 'address', type: 'varchar', isNullable: false },
+                    { name: 'capacity', type: 'int', isNullable: false },
+                ],
+            }),
+            true,
+        );
+
+        // Events table
+        await queryRunner.createTable(
+            new Table({
+                name: 'events',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'title', type: 'varchar', isNullable: false },
+                    { name: 'description', type: 'text', isNullable: true },
+                    { name: 'start_date', type: 'timestamp with time zone', isNullable: false },
+                    { name: 'end_date', type: 'timestamp with time zone', isNullable: false },
+                    { name: 'is_recurring', type: 'boolean', default: false },
+                    { name: 'recurrence_rule', type: 'varchar', isNullable: true },
+                    { name: 'venue_id', type: 'int', isNullable: false },
+                    { name: 'category_id', type: 'int', isNullable: false },
+                    { name: 'organizer_id', type: 'uuid', isNullable: false },
+                    { name: 'created_at', type: 'timestamp with time zone', default: 'now()' },
+                    { name: 'updated_at', type: 'timestamp with time zone', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+        await queryRunner.createForeignKey(
+            'events',
+            new TableForeignKey({
+                columnNames: ['venue_id'],
+                referencedTableName: 'venues',
+                referencedColumnNames: ['id'],
+                onDelete: 'RESTRICT',
+            }),
+        );
+        await queryRunner.createForeignKey(
+            'events',
+            new TableForeignKey({
+                columnNames: ['category_id'],
+                referencedTableName: 'categories',
+                referencedColumnNames: ['id'],
+                onDelete: 'RESTRICT',
+            }),
+        );
+        await queryRunner.createForeignKey(
+            'events',
+            new TableForeignKey({
+                columnNames: ['organizer_id'],
+                referencedTableName: 'users',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+
+        // Tickets table (ticket definitions)
+        await queryRunner.createTable(
+            new Table({
+                name: 'tickets',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'event_id', type: 'uuid', isNullable: false },
+                    { name: 'name', type: 'varchar', isNullable: false },
+                    { name: 'price', type: 'numeric(10,2)', default: '0' },
+                    { name: 'quantity', type: 'int', default: '0' },
+                    { name: 'created_at', type: 'timestamp with time zone', default: 'now()' },
+                    { name: 'updated_at', type: 'timestamp with time zone', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+        await queryRunner.createForeignKey(
+            'tickets',
+            new TableForeignKey({
+                columnNames: ['event_id'],
+                referencedTableName: 'events',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+
+        // Attendees table (registrations)
+        await queryRunner.createTable(
+            new Table({
+                name: 'attendees',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'event_id', type: 'uuid', isNullable: false },
+                    { name: 'user_id', type: 'uuid', isNullable: false },
+                    { name: 'ticket_id', type: 'uuid', isNullable: true },
+                    { name: 'status', type: 'varchar', default: "'registered'" },
+                    { name: 'created_at', type: 'timestamp with time zone', default: 'now()' },
+                    { name: 'updated_at', type: 'timestamp with time zone', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+        await queryRunner.createForeignKey(
+            'attendees',
+            new TableForeignKey({
+                columnNames: ['event_id'],
+                referencedTableName: 'events',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+        await queryRunner.createForeignKey(
+            'attendees',
+            new TableForeignKey({
+                columnNames: ['user_id'],
+                referencedTableName: 'users',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+        await queryRunner.createForeignKey(
+            'attendees',
+            new TableForeignKey({
+                columnNames: ['ticket_id'],
+                referencedTableName: 'tickets',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('attendees');
+        await queryRunner.dropTable('tickets');
+        await queryRunner.dropTable('events');
+        await queryRunner.dropTable('venues');
+        await queryRunner.dropTable('categories');
+        await queryRunner.dropTable('user_roles');
+        await queryRunner.dropTable('users');
+        await queryRunner.dropTable('roles');
+        await queryRunner.query(`DROP EXTENSION "uuid-ossp";`);
+    }
+}

--- a/backend/migrations/001-create-uuid-extension.ts
+++ b/backend/migrations/001-create-uuid-extension.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateUuidExtension001 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP EXTENSION IF EXISTS "uuid-ossp";`);
+  }
+}

--- a/backend/migrations/002-create-roles.ts
+++ b/backend/migrations/002-create-roles.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateRoles002 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'roles',
+        columns: [
+          { name: 'id', type: 'serial', isPrimary: true },
+          { name: 'name', type: 'varchar', isUnique: true, isNullable: false },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('roles');
+  }
+}

--- a/backend/migrations/003-create-users.ts
+++ b/backend/migrations/003-create-users.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateUsers003 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'users',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          { name: 'email', type: 'varchar', isUnique: true, isNullable: false },
+          { name: 'password', type: 'varchar', isNullable: false },
+          { name: 'first_name', type: 'varchar', isNullable: false },
+          { name: 'last_name', type: 'varchar', isNullable: false },
+          { name: 'created_at', type: 'timestamp with time zone', default: 'now()' },
+          { name: 'updated_at', type: 'timestamp with time zone', default: 'now()' },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('users');
+  }
+}

--- a/backend/migrations/004-create-user-roles.ts
+++ b/backend/migrations/004-create-user-roles.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateUserRoles004 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'user_roles',
+        columns: [
+          { name: 'user_id', type: 'uuid', isPrimary: true },
+          { name: 'role_id', type: 'int', isPrimary: true },
+        ],
+      }),
+      true,
+    );
+    await queryRunner.createForeignKey(
+      'user_roles',
+      new TableForeignKey({
+        columnNames: ['user_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'users',
+        onDelete: 'CASCADE',
+      }),
+    );
+    await queryRunner.createForeignKey(
+      'user_roles',
+      new TableForeignKey({
+        columnNames: ['role_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'roles',
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('user_roles');
+  }
+}

--- a/backend/migrations/005-create-categories.ts
+++ b/backend/migrations/005-create-categories.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateCategories005 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'categories',
+        columns: [
+          { name: 'id', type: 'serial', isPrimary: true },
+          { name: 'name', type: 'varchar', isUnique: true, isNullable: false },
+          { name: 'description', type: 'text', isNullable: true },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('categories');
+  }
+}

--- a/backend/migrations/006-create-venues.ts
+++ b/backend/migrations/006-create-venues.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateVenues006 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'venues',
+        columns: [
+          { name: 'id', type: 'serial', isPrimary: true },
+          { name: 'name', type: 'varchar', isNullable: false },
+          { name: 'description', type: 'text', isNullable: true },
+          { name: 'address', type: 'varchar', isNullable: false },
+          { name: 'capacity', type: 'int', isNullable: false },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('venues');
+  }
+}

--- a/backend/migrations/007-create-events.ts
+++ b/backend/migrations/007-create-events.ts
@@ -1,0 +1,63 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateEvents007 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'events',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          { name: 'title', type: 'varchar', isNullable: false },
+          { name: 'description', type: 'text', isNullable: true },
+          { name: 'start_date', type: 'timestamp with time zone', isNullable: false },
+          { name: 'end_date', type: 'timestamp with time zone', isNullable: false },
+          { name: 'is_recurring', type: 'boolean', default: false },
+          { name: 'recurrence_rule', type: 'varchar', isNullable: true },
+          { name: 'venue_id', type: 'int', isNullable: false },
+          { name: 'category_id', type: 'int', isNullable: false },
+          { name: 'organizer_id', type: 'uuid', isNullable: false },
+          { name: 'created_at', type: 'timestamp with time zone', default: 'now()' },
+          { name: 'updated_at', type: 'timestamp with time zone', default: 'now()' },
+        ],
+      }),
+      true,
+    );
+    await queryRunner.createForeignKey(
+      'events',
+      new TableForeignKey({
+        columnNames: ['venue_id'],
+        referencedTableName: 'venues',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+    );
+    await queryRunner.createForeignKey(
+      'events',
+      new TableForeignKey({
+        columnNames: ['category_id'],
+        referencedTableName: 'categories',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+    );
+    await queryRunner.createForeignKey(
+      'events',
+      new TableForeignKey({
+        columnNames: ['organizer_id'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('events');
+  }
+}

--- a/backend/migrations/008-create-tickets.ts
+++ b/backend/migrations/008-create-tickets.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateTickets008 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'tickets',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          { name: 'event_id', type: 'uuid', isNullable: false },
+          { name: 'name', type: 'varchar', isNullable: false },
+          { name: 'price', type: 'numeric(10,2)', default: '0' },
+          { name: 'quantity', type: 'int', default: '0' },
+          { name: 'created_at', type: 'timestamp with time zone', default: 'now()' },
+          { name: 'updated_at', type: 'timestamp with time zone', default: 'now()' },
+        ],
+      }),
+      true,
+    );
+    await queryRunner.createForeignKey(
+      'tickets',
+      new TableForeignKey({
+        columnNames: ['event_id'],
+        referencedTableName: 'events',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('tickets');
+  }
+}

--- a/backend/migrations/009-create-attendees.ts
+++ b/backend/migrations/009-create-attendees.ts
@@ -1,0 +1,58 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateAttendees009 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'attendees',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          { name: 'event_id', type: 'uuid', isNullable: false },
+          { name: 'user_id', type: 'uuid', isNullable: false },
+          { name: 'ticket_id', type: 'uuid', isNullable: true },
+          { name: 'status', type: 'varchar', default: "'registered'" },
+          { name: 'created_at', type: 'timestamp with time zone', default: 'now()' },
+          { name: 'updated_at', type: 'timestamp with time zone', default: 'now()' },
+        ],
+      }),
+      true,
+    );
+    await queryRunner.createForeignKey(
+      'attendees',
+      new TableForeignKey({
+        columnNames: ['event_id'],
+        referencedTableName: 'events',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+    await queryRunner.createForeignKey(
+      'attendees',
+      new TableForeignKey({
+        columnNames: ['user_id'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+    await queryRunner.createForeignKey(
+      'attendees',
+      new TableForeignKey({
+        columnNames: ['ticket_id'],
+        referencedTableName: 'tickets',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('attendees');
+  }
+}


### PR DESCRIPTION
```
This pull request introduces the foundational backend setup and database migrations for the project. Below are the key changes:

### Added
- **Database Migrations**:
  - Created tables for users, roles, events, venues, categories, tickets, and attendees.
  - Established foreign key relationships and constraints to maintain referential integrity.
  - Enabled the `uuid-ossp` extension for UUID generation.
  - Added cascading delete behaviors and rollback support for all migrations.
- **Backend Setup**:
  - Initialized a NestJS application with core configurations.
  - Integrated Swagger documentation for API definition.
  - Added environment configuration via `.env.example`, including the `PORT` variable.
  - Configured TypeORM for database interaction with PostgreSQL.
  - Added validation and API prefix setup.
  - Defined modular structure with modules such as Users, Auth, Events, Tickets, Venues, Categories, and Attendees.
- **Project Configuration**:
  - Added TypeScript configuration (`tsconfig.json` and `tsconfig.build.json`).
  - Introduced `nest-cli.json` for a consistent project scaffold.
  - Included migration scripts in `package.json` for streamlined migration handling.

### Updated
- Added a detailed `README.md` to provide setup instructions, structure details, and usage guidelines for developers.
```